### PR TITLE
[Backport] Fix for #12081: missing translations in the js-translations.json

### DIFF
--- a/app/code/Magento/Bundle/Model/Product/Type.php
+++ b/app/code/Magento/Bundle/Model/Product/Type.php
@@ -497,12 +497,12 @@ class Type extends \Magento\Catalog\Model\Product\Type\AbstractType
 
         foreach ($selections as $selection) {
             if ($selection->getProductId() == $optionProduct->getId()) {
-                foreach ($options as &$option) {
-                    if ($option->getCode() == 'selection_qty_' . $selection->getSelectionId()) {
+                foreach ($options as $quoteItemOption) {
+                    if ($quoteItemOption->getCode() == 'selection_qty_' . $selection->getSelectionId()) {
                         if ($optionUpdateFlag) {
-                            $option->setValue(intval($option->getValue()));
+                            $quoteItemOption->setValue(intval($quoteItemOption->getValue()));
                         } else {
-                            $option->setValue($value);
+                            $quoteItemOption->setValue($value);
                         }
                     }
                 }

--- a/app/code/Magento/Rule/Model/Action/AbstractAction.php
+++ b/app/code/Magento/Rule/Model/Action/AbstractAction.php
@@ -46,13 +46,16 @@ abstract class AbstractAction extends \Magento\Framework\DataObject implements A
 
         $this->loadAttributeOptions()->loadOperatorOptions()->loadValueOptions();
 
-        foreach (array_keys($this->getAttributeOption()) as $attr) {
-            $this->setAttribute($attr);
-            break;
+        $attributes = $this->getAttributeOption();
+        if ($attributes) {
+            reset($attributes);
+            $this->setAttribute(key($attributes));
         }
-        foreach (array_keys($this->getOperatorOption()) as $operator) {
-            $this->setOperator($operator);
-            break;
+
+        $operators = $this->getOperatorOption();
+        if ($operators) {
+            reset($operators);
+            $this->setOperator(key($operators));
         }
     }
 

--- a/app/code/Magento/Rule/Model/Condition/Combine.php
+++ b/app/code/Magento/Rule/Model/Condition/Combine.php
@@ -48,6 +48,7 @@ class Combine extends AbstractCondition
     }
 
     /* start aggregator methods */
+
     /**
      * @return $this
      */

--- a/app/code/Magento/Rule/Model/Condition/Combine.php
+++ b/app/code/Magento/Rule/Model/Condition/Combine.php
@@ -42,10 +42,8 @@ class Combine extends AbstractCondition
         $this->loadAggregatorOptions();
         $options = $this->getAggregatorOptions();
         if ($options) {
-            foreach (array_keys($options) as $aggregator) {
-                $this->setAggregator($aggregator);
-                break;
-            }
+            reset($options);
+            $this->setAggregator(key($options));
         }
     }
 
@@ -85,9 +83,10 @@ class Combine extends AbstractCondition
     public function getAggregatorElement()
     {
         if ($this->getAggregator() === null) {
-            foreach (array_keys($this->getAggregatorOption()) as $key) {
-                $this->setAggregator($key);
-                break;
+            $options = $this->getAggregatorOption();
+            if ($options) {
+                reset($options);
+                $this->setAggregator(key($options));
             }
         }
         return $this->getForm()->addField(

--- a/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
+++ b/app/code/Magento/Sales/Model/Order/Email/Sender/OrderSender.php
@@ -135,7 +135,7 @@ class OrderSender extends Sender
          */
         $this->eventManager->dispatch(
             'email_order_set_template_vars_before',
-            ['sender' => $this, 'transport' => $transportObject->getData(), 'transportObject' => $transportObject]
+            ['sender' => $this, 'transport' => $transportObject, 'transportObject' => $transportObject]
         );
 
         $this->templateContainer->setTemplateVars($transportObject->getData());

--- a/app/code/Magento/Translation/etc/di.xml
+++ b/app/code/Magento/Translation/etc/di.xml
@@ -61,6 +61,7 @@
                 <item name="translate_wrapping" xsi:type="string"><![CDATA[~translate\=("')([^\'].*?)\'\"~]]></item>
                 <item name="mage_translation_widget" xsi:type="string"><![CDATA[~(?:\$|jQuery)\.mage\.__\((?s)[^'"]*?(['"])(.+?)(?<!\\)\1(?s).*?\)~]]></item>
                 <item name="mage_translation_static" xsi:type="string"><![CDATA[~\$t\((?s)[^'"]*?(["'])(.+?)\1(?s).*?\)~]]></item>
+                <item name="translate_args" xsi:type="string"><![CDATA[~translate args\=("|'|"')([^\'].*?)('"|'|")~]]></item>
             </argument>
         </arguments>
     </type>

--- a/app/design/frontend/Magento/blank/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/blank/web/css/source/components/_modals_extend.less
@@ -64,6 +64,8 @@
     }
 
     .modal-popup {
+        pointer-events: none;
+
         .modal-title {
             .lib-css(border-bottom, @modal-title__border);
             .lib-css(font-weight, @font-weight__light);

--- a/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
+++ b/app/design/frontend/Magento/luma/web/css/source/components/_modals_extend.less
@@ -64,6 +64,8 @@
     }
 
     .modal-popup {
+        pointer-events: none;
+
         .modal-title {
             .lib-css(border-bottom, @modal-title__border);
             .lib-css(font-weight, @font-weight__light);

--- a/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
+++ b/lib/internal/Magento/Framework/View/Model/Layout/Merge.php
@@ -427,6 +427,9 @@ class Merge implements \Magento\Framework\View\Layout\ProcessorInterface
         if ($result) {
             $this->addUpdate($result);
             $this->pageLayout = $this->_loadCache($cacheIdPageLayout);
+            foreach ($this->getHandles() as $handle) {
+                $this->allHandles[$handle] = $this->handleProcessed;
+            }
             return $this;
         }
 

--- a/lib/web/css/source/lib/_forms.less
+++ b/lib/web/css/source/lib/_forms.less
@@ -465,11 +465,9 @@
     .lib-css(margin, @_margin);
     .lib-css(padding, @_padding);
     letter-spacing: -.31em;
-    //word-spacing: -.43em;
 
     > * {
         letter-spacing: normal;
-        //word-spacing: normal;
     }
 
     > .legend {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/13528
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
This PR adds an additional pattern to the module responsible for generating the js-translations.json file. The translation routine doesn't translate strings in tags like`<translate args="This won't be translated"`.

This is related to (but doesn't fix) https://github.com/magento/magento2/pull/13471 where the Html parser of the phrase collection module is also missing a pattern matching the `<translate args=` tags.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. magento/magento2#12081: Magento 2.2.0: Translations for 'Item in Cart' missing in mini cart.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Clean Magento installation with a translation file translating the string "Item in Cart" from Magento_Checkout.
2. Run setup:static-content:deploy
3. Without the fix, the string isn't in the generated js-translations.json file. With the fix it will be.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
